### PR TITLE
Newer sphinxcontrib-bibtex requires bibtex_bibfiles variable in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,6 +158,7 @@ latex_documents = [
     )
 ]
 
+bibtex_bibfiles = ["abydos.bib"]
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
The latest version of sphinxcontrib-bibtex (2.4.1), and probably some older versions too, requires `conf.py` to define `bibtext_bibfiles`. This patch does this (and nothing else).