### PR TITLE
Change occurrences of `np.float_` to `np.float64` as it has been removed in numpy>2.0.0

### DIFF
--- a/abydos/distance/_aline.py
+++ b/abydos/distance/_aline.py
@@ -22,7 +22,7 @@ ALINE alignment, similarity, and distance
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Tuple, Union, cast
 
-from numpy import float_, inf, zeros
+from numpy import float16, inf, zeros
 
 from ._distance import _Distance
 

--- a/abydos/distance/_aline.py
+++ b/abydos/distance/_aline.py
@@ -22,7 +22,7 @@ ALINE alignment, similarity, and distance
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Tuple, Union, cast
 
-from numpy import float16, inf, zeros
+from numpy import float64, inf, zeros
 
 from ._distance import _Distance
 
@@ -1593,7 +1593,7 @@ class ALINE(_Distance):
 
         tar_len = len(tar_tok)
 
-        s_mat = zeros((src_len + 1, tar_len + 1), dtype=float_)
+        s_mat = zeros((src_len + 1, tar_len + 1), dtype=float64)
 
         if self._mode == 'global':
             for i in range(1, src_len + 1):

--- a/abydos/distance/_bisim.py
+++ b/abydos/distance/_bisim.py
@@ -21,7 +21,7 @@ BI-SIM similarity
 
 from typing import Any, cast
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._distance import _Distance

--- a/abydos/distance/_discounted_levenshtein.py
+++ b/abydos/distance/_discounted_levenshtein.py
@@ -175,7 +175,7 @@ class DiscountedLevenshtein(Levenshtein):
         else:
             discount_from = [1, 1]
 
-        d_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.float_)
+        d_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.float64)
         if backtrace:
             trace_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.int8)
         for i in range(1, src_len + 1):

--- a/abydos/distance/_editex.py
+++ b/abydos/distance/_editex.py
@@ -23,7 +23,7 @@ from sys import float_info
 from typing import Any, Tuple, cast
 from unicodedata import normalize as unicode_normalize
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._distance import _Distance

--- a/abydos/distance/_flexmetric.py
+++ b/abydos/distance/_flexmetric.py
@@ -32,7 +32,7 @@ from typing import (
     cast,
 )
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._distance import _Distance

--- a/abydos/distance/_gotoh.py
+++ b/abydos/distance/_gotoh.py
@@ -20,7 +20,7 @@ Gotoh score
 """
 from typing import Any, Callable, Optional, cast
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._needleman_wunsch import NeedlemanWunsch

--- a/abydos/distance/_levenshtein.py
+++ b/abydos/distance/_levenshtein.py
@@ -138,7 +138,7 @@ class Levenshtein(_Distance):
         tar_len = len(tar)
         max_len = max(src_len, tar_len)
 
-        d_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.float_)
+        d_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.float64)
         if backtrace:
             trace_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.int8)
         for i in range(src_len + 1):

--- a/abydos/distance/_meta_levenshtein.py
+++ b/abydos/distance/_meta_levenshtein.py
@@ -31,7 +31,7 @@ from typing import (
     cast,
 )
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._distance import _Distance

--- a/abydos/distance/_needleman_wunsch.py
+++ b/abydos/distance/_needleman_wunsch.py
@@ -21,7 +21,7 @@ Needleman-Wunsch score
 
 from typing import Any, Callable, Dict, Optional, Tuple, cast
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._distance import _Distance

--- a/abydos/distance/_phonetic_edit_distance.py
+++ b/abydos/distance/_phonetic_edit_distance.py
@@ -147,7 +147,7 @@ class PhoneticEditDistance(Levenshtein):
         src_list = ipa_to_features(src)
         tar_list = ipa_to_features(tar)
 
-        d_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.float_)
+        d_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.float64)
         if backtrace:
             trace_mat = np.zeros((src_len + 1, tar_len + 1), dtype=np.int8)
         for i in range(1, src_len + 1):

--- a/abydos/distance/_smith_waterman.py
+++ b/abydos/distance/_smith_waterman.py
@@ -21,7 +21,7 @@ Smith-Waterman score
 
 from typing import Any, Callable, Optional, cast
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._needleman_wunsch import NeedlemanWunsch

--- a/abydos/distance/_typo.py
+++ b/abydos/distance/_typo.py
@@ -23,7 +23,7 @@ from itertools import chain
 from math import log
 from typing import Any, Dict, Tuple, cast
 
-from numpy import float_ as np_float
+from numpy import float64 as np_float
 from numpy import zeros as np_zeros
 
 from ._distance import _Distance


### PR DESCRIPTION
Changed all occurrences, afaik.
Should work with versions of python>=3.10 and numpy>2.0.0.

- preferred np.float64 because of high range, this can be changed in the case of needing performance without a high range limitation.
- some type-checking further on became obsolete because of the change forcing the data type to `np.float64`.  (e.g. `type(data) in [np.float64, np.float32]`)

